### PR TITLE
Fix typo around CA state specific scraping

### DIFF
--- a/contributing/state-specific.rst
+++ b/contributing/state-specific.rst
@@ -17,7 +17,7 @@ To download the data for the current session::
 
 This will start a local MySQL image as well, that image will need to stay up for the next step, which is running a scrape like normal::
 
-  docker-compose run --rm scrape ca bills --fast
+  docker-compose run --rm ca-scrape ca bills --fast
 
 
 


### PR DESCRIPTION
Fixes typo in documentation around CA specific instructions. Referenced in this issue: https://github.com/openstates/issues/issues/146