### PR TITLE
Hackathon Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ _build/
 .vscode
 *.DS_Store
 site/
+.idea/

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -12,7 +12,8 @@ No matter how experienced you are, it is a good idea to read through this sectio
 
 No worries if you aren't an expert though, we'll walk you through the
 steps. And as for Python, if you've written other languages like
-Javascript or Ruby you'll probably be just fine.
+Javascript or Ruby you'll probably be just fine. Here's a [great guide](https://realpython.com/intro-to-pyenv/) on 
+getting started installing and managing Python versions. 
 
 Don't be afraid to [ask for help](../index.md#communication) either!
 

--- a/docs/contributing/openstates-org.md
+++ b/docs/contributing/openstates-org.md
@@ -7,15 +7,16 @@ site is built in Django and includes the web frontend and API.
 
 Fork and clone the openstates.org repository:
 
--   Visit <https://github.com/openstates/openstates.org> and click the
+- Visit <https://github.com/openstates/openstates.org> and click the
     'Fork' button.
 
--   Clone your fork using your tool of choice or the command line:
+- Clone your fork using your tool of choice or the command line:
 
         $ git clone git@github.com:yourname/openstates.org.git
         Cloning into 'openstates.org'...
 
--   And remember to `install pre-commit <pre-commit>`:
+- Be sure to run `poetry install` to fetch the correct version of dependencies.
+- And remember to `install pre-commit <pre-commit>`:
 
         $ pre-commit install
         pre-commit installed at .git/hooks/pre-commit
@@ -63,7 +64,16 @@ Other Stuff:
 
 Simply running `docker-compose up` should start django & the database,
 then browse to <http://localhost:8000> and you'll be looking at your
-own local copy of openstates.org
+own local copy of openstates.org. In a separate terminal window, run `npm run build` and `npm run start` to see the 
+site's react and style components.
+
+!!! note 
+    
+    If you're running into issues with models not being found or an incorrectly configured virtual environment, running
+    `docker-compose build` should help to fix it.
+
+If you have issues getting your instance up and running, please document the
+errors you're seeing and [reach out](../index.md#communication).
 
 ## Running outside of Docker
 

--- a/docs/contributing/scrapers.md
+++ b/docs/contributing/scrapers.md
@@ -11,18 +11,20 @@ learn from.
 
 Fork and clone the main scraper repository:
 
--   Visit <https://github.com/openstates/openstates-scrapers> and
+- Visit <https://github.com/openstates/openstates-scrapers> and
     click the 'Fork' button.
 
--   Clone your fork using your tool of choice or the command line:
+- Clone your fork using your tool of choice or the command line:
 
         $ git clone git@github.com:yourname/openstates-scrapers.git
         Cloning into 'openstates-scrapers'...
 
--   And remember to `install pre-commit <pre-commit>` hooks:
+- And remember to `install pre-commit <pre-commit>` hooks:
 
         $ pre-commit install
         pre-commit installed at .git/hooks/pre-commit
+
+- Be sure to run `poetry install` to fetch the correct version of dependencies.
 
 !!! warning
 


### PR DESCRIPTION
Ran into some issues while trying to get others setup on OS during a hackathon. Updated documentation to include
 - a quick guide to Python & Pyenv for total newbies
 - reminder to run `poetry install` in each repo incase anyone skips the index page (like we were guilty of)
 - including `npm run start` for os.org to get react components and styling locally
 -  reminder that `docker-compose build` is useful occassionally
 - invitation to reach out if there are any issues getting os.org running locally. !we had some issues due to package dependancies, but may be worth while to get snapshots if others run into it